### PR TITLE
#2 : Fix Create Account button tap issue during registration

### DIFF
--- a/wedding2u_app/lib/application/sign_up.dart
+++ b/wedding2u_app/lib/application/sign_up.dart
@@ -13,7 +13,8 @@ class SignUpService {
     required String role,
   }) async {
     // Authenticate the user and get UID
-    String uid = await _authService.createUser(email: email, password: password);
+    String uid =
+        await _authService.createUser(email: email, password: password);
 
     // Save user data to Firestore
     await _firestoreService.addUser(
@@ -28,3 +29,5 @@ class SignUpService {
     );
   }
 }
+
+// Patch change : Fix Create Account button tap issue during registration


### PR DESCRIPTION
This PR is created to fix the issue where the "Create Account" button does not respond when tapped during the registration process, ensuring the button correctly triggers the account creation flow and improving the overall user experience.

Issue : #2 

